### PR TITLE
Bugfix: Make newer version of ansible explicit for Vagrant

### DIFF
--- a/auto/Vagrantfile
+++ b/auto/Vagrantfile
@@ -162,6 +162,7 @@ Vagrant.configure(2) do |config|
         # XXX DISABLED: Ansible will read the environment variable if present
         #ansible.config_file = ansible_cfg
         ansible.playbook = 'ansible/dummy_vagrant_provision.yml'
+	ansible.compatibility_mode = '2.0'
       end
 
       # ... and shutdown


### PR DESCRIPTION
Bugfix for where the version of ansible could not be detected anymore after an upgrade of Vagrant. When Vagrant does not detect that ansible is version >= 2.0, ansible.postix.sync breaks.